### PR TITLE
Allow clause to be inserted in non top-level functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
         Increment ->
-            ( { model | counter = model.counter + 1 }, Cmd.none ) 
+            ( { model | counter = model.counter + 1 }, Cmd.none )
 
         Decrement ->
             ( { model | counter = model.counter - 1 },  Cmd.none )
@@ -93,6 +93,7 @@ update msg model =
 - **Install.Initializer**: Add a field to the body of an initializer function where the return value is of the form `( Model, Cmd msg )`. For more details, see the [docs](https://package.elm-lang.org/packages/jxxcarlson/elm-review-codeinstaller/latest/Install-Initializer).
 - **Install.TypeVariant**: Add a variant to a specified type in a specified module. For more details, see the [docs](https://package.elm-lang.org/packages/jxxcarlson/elm-review-codeinstaller/latest/Install-TypeVariant).
 - **Install.Function**: Replace a function in a given module with a new implementation or add that function definition if it is not present in the module. For more details, see the [docs](https://package.elm-lang.org/packages/jxxcarlson/elm-review-codeinstaller/latest/Install-Function).
+- **Install.Import**: Add import statements to a given module. For more details, see the [docs](https://package.elm-lang.org/packages/jxxcarlson/elm-review-codeinstaller/latest/Install-Import).
 
 ## Try it out
 To test the review code in its current state, try running this in a clean Lamdera project:

--- a/src/Install/ClauseInCase.elm
+++ b/src/Install/ClauseInCase.elm
@@ -57,7 +57,6 @@ import List.Extra
 import Maybe.Extra
 import Review.Fix as Fix exposing (Fix)
 import Review.Rule as Rule exposing (Error, Rule)
-import Set exposing (Set)
 import String.Extra
 
 

--- a/src/Install/ClauseInCase.elm
+++ b/src/Install/ClauseInCase.elm
@@ -363,7 +363,7 @@ addMissingCase { row, column } isClauseStringPattern prefix clause functionCall 
                 clause
 
         insertion =
-            "\n" ++ prefix ++ clauseToAdd ++ " -> " ++ functionCall ++ "\n\n"
+            "\n" ++ prefix ++ clauseToAdd ++ " -> " ++ functionCall ++ "\n"
     in
     Fix.insertAt { row = row, column = column } insertion
 

--- a/src/Install/ClauseInCase.elm
+++ b/src/Install/ClauseInCase.elm
@@ -253,6 +253,9 @@ visitFunction namespace clause functionCall ignored expressionNode insertAt cust
                     Nothing ->
                         ( [ Rule.error couldNotFindCaseError (Node.range expressionNode) ], context )
 
+        ParenthesizedExpression node ->
+            visitFunction namespace clause functionCall ignored node insertAt customError context
+
         _ ->
             ( [ Rule.error couldNotFindCaseError (Node.range expressionNode) ], context )
 
@@ -296,10 +299,10 @@ rangeToInsertClause insertAt isClauseStringPattern cases expression =
                     pattern
                         |> Tuple.second
                         |> Node.range
-                        |> (\range -> ( range, 2, lastClauseStartingColumn ))
+                        |> (\range -> ( range, 1, lastClauseStartingColumn ))
 
                 Nothing ->
-                    ( Node.range lastClauseExpression, 2, 0 )
+                    ( Node.range lastClauseExpression, 1, 0 )
 
         AtBeginning ->
             let
@@ -325,7 +328,7 @@ rangeToInsertClause insertAt isClauseStringPattern cases expression =
                 range =
                     Node.range lastClauseExpression
             in
-            ( range, 2, lastClauseStartingColumn )
+            ( range, 1, lastClauseStartingColumn )
 
 
 errorWithFix : CustomError -> Bool -> String -> String -> Node a -> Maybe ( Range, Int, Int ) -> Error {}
@@ -340,7 +343,7 @@ errorWithFix (CustomError customError) isClauseStringPattern clause functionCall
                         { row = range.end.row + verticalOffset, column = 0 }
 
                     prefix =
-                        "\n" ++ String.repeat horizontalOffset " "
+                        String.repeat horizontalOffset " "
                 in
                 [ addMissingCase insertionPoint isClauseStringPattern prefix clause functionCall ]
 
@@ -360,7 +363,7 @@ addMissingCase { row, column } isClauseStringPattern prefix clause functionCall 
                 clause
 
         insertion =
-            prefix ++ clauseToAdd ++ " -> " ++ functionCall ++ "\n\n"
+            "\n" ++ prefix ++ clauseToAdd ++ " -> " ++ functionCall ++ "\n\n"
     in
     Fix.insertAt { row = row, column = column } insertion
 

--- a/src/Install/ClauseInCase.elm
+++ b/src/Install/ClauseInCase.elm
@@ -303,11 +303,22 @@ rangeToInsertClause insertAt isClauseStringPattern cases expression =
 
         AtBeginning ->
             let
-                -- The -2 is to account for the `case` keyword and the space after it
+                -- If there are other clauses, the first clause will take the start of other clauses as reference.
+                otherClausesOffset =
+                    cases
+                        |> List.map (\( pattern, _ ) -> Node.range pattern |> .start >> .column)
+                        |> List.minimum
+                        |> Maybe.map (\x -> x - 1)
+
+                -- If there are no other clauses, the first clause will take the case expression as reference. The -2 is to account for the `case` keyword and the space after it
                 firstClauseOffset =
                     (Node.range expression).start.column - 2
+
+                clauseOffset =
+                    otherClausesOffset
+                        |> Maybe.withDefault firstClauseOffset
             in
-            ( Node.range expression, 1, firstClauseOffset )
+            ( Node.range expression, 1, clauseOffset )
 
         AtEnd ->
             let

--- a/src/Install/Import.elm
+++ b/src/Install/Import.elm
@@ -126,7 +126,6 @@ fixError config context =
                 ++ " "
                 |> addAlias config.importedModuleAlias
                 |> addExposing config.exposedValues
-                |> Debug.log "importText"
 
         addAlias : Maybe String -> String -> String
         addAlias mAlias str =

--- a/src/Install/Import.elm
+++ b/src/Install/Import.elm
@@ -19,11 +19,10 @@ To add the statement `import Foo.Bar as FB exposing (a, b, c)` to the `Frontend`
 
 import Elm.Syntax.Import exposing (Import)
 import Elm.Syntax.ModuleName exposing (ModuleName)
-import Elm.Syntax.Node as Node exposing (Node(..))
+import Elm.Syntax.Node as Node exposing (Node)
 import Elm.Syntax.Range as Range exposing (Range)
-import Review.Fix as Fix exposing (Fix)
+import Review.Fix as Fix
 import Review.Rule as Rule exposing (Error, Rule)
-import Set exposing (Set)
 
 
 {-|

--- a/tests/Install/ClauseInCaseTest2.elm
+++ b/tests/Install/ClauseInCaseTest2.elm
@@ -16,6 +16,7 @@ all =
         , Run.testFix test3
         , Run.testFix test4
         , Run.testFix test5
+        , Run.testFix test6
         ]
 
 
@@ -108,8 +109,8 @@ updateFromFrontend sessionId clientId msg model =
             in
             ( { model | counter = newCounter }, broadcast (CounterNewValue newCounter clientId) )
 
-
         ResetCounter -> ( { model | counter = 0 }, broadcast (CounterNewValue 0 clientId) )
+
 
 
 """
@@ -197,8 +198,8 @@ update msg model =
         Increment ->
             ( { model | counter = model.counter + 1 }, sendToBackend CounterIncremented )
 
-
         Reset -> ( { model | counter = 0 }, sendToBackend CounterReset )
+
 
         Decrement ->
             ( { model | counter = model.counter - 1 }, sendToBackend CounterDecremented )
@@ -305,8 +306,8 @@ stringToPhilosopher str =
             "Aristotle" ->
                 Just Aristotle
 
-
             "Aspasia" -> Just Aspasia
+
 
             _ ->
                 Nothing"""
@@ -364,7 +365,6 @@ isStringPattern nodePattern =
     in
     case pattern of
         StringPattern _ -> True
-
 
         _ -> False
 
@@ -432,3 +432,102 @@ errorFix context node maybeError =
             []
     , context)
     """
+
+
+
+-- TEST 6
+
+
+test6 : { description : String, src : String, rule : Rule, under : String, fixed : String, message : String }
+test6 =
+    { description = "Test 6: should add clause when case is inside parenthesized expression"
+    , src = src6
+    , rule = rule6
+    , under = under6
+    , fixed = fixed6
+    , message = "Add handler for Sun"
+    }
+
+
+src6 : String
+src6 =
+    """module WeekShiftForm exposing(..)
+
+getShiftFormFromWeekday weekday =
+    (case weekday of
+        Mon ->
+            .monday
+
+        Tue ->
+            .tuesday
+
+        Wed ->
+            .wednesday
+
+        Thu ->
+            .thursday
+
+        Fri ->
+            .friday
+
+        Sat ->
+            .saturday
+    )"""
+
+
+rule6 : Rule
+rule6 =
+    Install.ClauseInCase.init "WeekShiftForm" "getShiftFormFromWeekday" "Sun" ".sunday"
+        |> Install.ClauseInCase.withInsertAfter "Sat"
+        |> Install.ClauseInCase.makeRule
+
+
+under6 : String
+under6 =
+    """case weekday of
+        Mon ->
+            .monday
+
+        Tue ->
+            .tuesday
+
+        Wed ->
+            .wednesday
+
+        Thu ->
+            .thursday
+
+        Fri ->
+            .friday
+
+        Sat ->
+            .saturday"""
+
+
+fixed6 : String
+fixed6 =
+    """module WeekShiftForm exposing(..)
+
+getShiftFormFromWeekday weekday =
+    (case weekday of
+        Mon ->
+            .monday
+
+        Tue ->
+            .tuesday
+
+        Wed ->
+            .wednesday
+
+        Thu ->
+            .thursday
+
+        Fri ->
+            .friday
+
+        Sat ->
+            .saturday
+
+        Sun -> .sunday
+
+    )"""

--- a/tests/Install/ClauseInCaseTest2.elm
+++ b/tests/Install/ClauseInCaseTest2.elm
@@ -112,7 +112,6 @@ updateFromFrontend sessionId clientId msg model =
         ResetCounter -> ( { model | counter = 0 }, broadcast (CounterNewValue 0 clientId) )
 
 
-
 """
 
 
@@ -125,7 +124,6 @@ updateFromFrontend sessionId clientId msg model =
     case msg of
 
         ResetCounter -> ( { model | counter = 0 }, broadcast (CounterNewValue 0 clientId) )
-
         CounterIncremented ->
             let
                 newCounter =
@@ -199,7 +197,6 @@ update msg model =
             ( { model | counter = model.counter + 1 }, sendToBackend CounterIncremented )
 
         Reset -> ( { model | counter = 0 }, sendToBackend CounterReset )
-
 
         Decrement ->
             ( { model | counter = model.counter - 1 }, sendToBackend CounterDecremented )
@@ -308,7 +305,6 @@ stringToPhilosopher str =
 
             "Aspasia" -> Just Aspasia
 
-
             _ ->
                 Nothing"""
 
@@ -367,7 +363,6 @@ isStringPattern nodePattern =
         StringPattern _ -> True
 
         _ -> False
-
 """
 
 
@@ -425,7 +420,6 @@ errorFix context node maybeError =
     (case maybeError of
 
         Just "" -> []
-
         Just error ->
             [Rule.error error Node.range node]
         Nothing ->
@@ -529,5 +523,4 @@ getShiftFormFromWeekday weekday =
             .saturday
 
         Sun -> .sunday
-
     )"""

--- a/tests/Install/ClauseInCaseTest2.elm
+++ b/tests/Install/ClauseInCaseTest2.elm
@@ -17,6 +17,7 @@ all =
         , Run.testFix test4
         , Run.testFix test5
         , Run.testFix test6
+        , Run.testFix test7
         ]
 
 
@@ -524,3 +525,71 @@ getShiftFormFromWeekday weekday =
 
         Sun -> .sunday
     )"""
+
+
+
+-- TEST 7 - IfBlock test
+
+
+test7 : { description : String, src : String, rule : Rule, under : String, fixed : String, message : String }
+test7 =
+    { description = "Test 7: should add clause when case is inside if block"
+    , src = src7
+    , rule = rule7
+    , under = under7
+    , fixed = fixed7
+    , message = "Add handler for Just []"
+    }
+
+
+src7 : String
+src7 =
+    """module Backend exposing (..)
+
+someFunction : Bool -> Maybe Data -> Result String Data
+someFunction condition maybeData =
+    if condition then
+        case maybeData of
+            Just data ->
+                Result.Ok data
+
+            Nothing ->
+                Result.Err "No data"
+    else
+        Result.Err "Condition not satisfied" """
+
+
+rule7 : Rule
+rule7 =
+    Install.ClauseInCase.init "Backend" "someFunction" "Just []" "Result.Err \"Empty data\""
+        |> Install.ClauseInCase.withInsertAtBeginning
+        |> Install.ClauseInCase.makeRule
+
+
+under7 : String
+under7 =
+    """case maybeData of
+            Just data ->
+                Result.Ok data
+
+            Nothing ->
+                Result.Err "No data\""""
+
+
+fixed7 : String
+fixed7 =
+    """module Backend exposing (..)
+
+someFunction : Bool -> Maybe Data -> Result String Data
+someFunction condition maybeData =
+    if condition then
+        case maybeData of
+
+            Just [] -> Result.Err "Empty data"
+            Just data ->
+                Result.Ok data
+
+            Nothing ->
+                Result.Err "No data"
+    else
+        Result.Err "Condition not satisfied" """

--- a/tests/Run.elm
+++ b/tests/Run.elm
@@ -3,6 +3,7 @@ module Run exposing
     , expectNoErrorsTest
     , expectNoErrorsTest_
     , testFix
+    , withOnly
     )
 
 import Review.Rule exposing (Rule)
@@ -35,6 +36,11 @@ expectErrorsTest description src rule =
             src
                 |> Review.Test.run rule
                 |> Review.Test.expectErrors []
+
+
+withOnly : Test -> Test
+withOnly t =
+    t |> Test.only
 
 
 type alias TestData =


### PR DESCRIPTION
Closes #7.

- Add support to nested (including deeply nestes) cases in all relevant expressions 
- Show an error messages when no case expression is found
- improve insertion of clauses at the beginning of case expressions
- fix CI problems
