### PR TITLE
Allow Install.Function to add new functions

### DIFF
--- a/preview/src/ReviewConfig.elm
+++ b/preview/src/ReviewConfig.elm
@@ -35,8 +35,8 @@ config =
       --  |> Install.Import.withAlias "FB"
       --  |> Install.Import.withExposedValues [ "a", "b", "c" ]
       --  |> Install.Import.makeRule
-        Install.Import.init "Frontend" "Foo.Bar" |> Install.Import.makeRule
-      , Install.Import.init "Frontend" "Box.Tux" |> Install.Import.makeRule
+      Install.Import.init "Frontend" "Foo.Bar" |> Install.Import.makeRule
+    , Install.Import.init "Frontend" "Box.Tux" |> Install.Import.makeRule
     ]
 
 

--- a/preview/src/ReviewConfig.elm
+++ b/preview/src/ReviewConfig.elm
@@ -16,27 +16,68 @@ import Install.FieldInTypeAlias
 import Install.Function
 import Install.Import
 import Install.Initializer
+import Install.Type
 import Install.TypeVariant
 import Review.Rule exposing (Rule)
 
 
 config : List Rule
 config =
-    [ --Install.TypeVariant.makeRule "Types" "ToBackend" "CounterReset"
-      --, Install.TypeVariant.makeRule "Types" "FrontendMsg" "Reset"
-      --, Install.ClauseInCase.init "Frontend" "update" "Reset" "( { model | counter = 0 }, sendToBackend CounterReset )"
-      --    |> Install.ClauseInCase.withInsertAfter "Increment"
-      --    |> Install.ClauseInCase.makeRule
-      --, Install.ClauseInCase.init "Backend" "updateFromFrontend" "CounterReset" "( { model | counter = 0 }, broadcast (CounterNewValue 0 clientId) )"
-      --    |> Install.ClauseInCase.makeRule
-      --, Install.Function.init [ "Frontend" ] "view" viewFunction |> Install.Function.makeRule
-      --
-      --Install.Import.init "Frontend" "Foo.Bar"
-      --  |> Install.Import.withAlias "FB"
-      --  |> Install.Import.withExposedValues [ "a", "b", "c" ]
-      --  |> Install.Import.makeRule
-      Install.Import.init "Frontend" "Foo.Bar" |> Install.Import.makeRule
-    , Install.Import.init "Frontend" "Box.Tux" |> Install.Import.makeRule
+    [ -- TYPES
+      Install.Type.makeRule "Types" "SignInState" [ "SignedOut", "SignUp", "SignedIn" ]
+
+    -- TYPES IMPORTS
+    , Install.Import.init "Types" "Auth.Common" |> Install.Import.makeRule
+    , Install.Import.init "Types" "Url" |> Install.Import.makeRule
+    , Install.Import.init "Types" "MagicLink.Types" |> Install.Import.makeRule
+    , Install.Import.init "Types" "User" |> Install.Import.makeRule
+    , Install.Import.init "Types" "Session" |> Install.Import.makeRule
+
+    -- Type Frontend, MagicLink
+    , Install.FieldInTypeAlias.makeRule "Types" "FrontendModel" "authFlow : Auth.Common.Flow"
+    , Install.FieldInTypeAlias.makeRule "Types" "FrontendModel" "authRedirectBaseUrl : Url"
+    , Install.FieldInTypeAlias.makeRule "Types" "FrontendModel" "signinForm : MagicLink.Types.SigninForm"
+    , Install.FieldInTypeAlias.makeRule "Types" "FrontendModel" "loginErrorMessage : Maybe String"
+    , Install.FieldInTypeAlias.makeRule "Types" "FrontendModel" "signInStatus : MagicLink.Types.SignInStatus"
+    , Install.FieldInTypeAlias.makeRule "Types" "FrontendModel" "currentUserData : Maybe User.LoginData"
+
+    -- Type Frontend, User
+    , Install.FieldInTypeAlias.makeRule "Types" "FrontendModel" "currentUser : Maybe User.User"
+    , Install.FieldInTypeAlias.makeRule "Types" "FrontendModel" "signInState : SignInState"
+    , Install.FieldInTypeAlias.makeRule "Types" "FrontendModel" "realname : String"
+    , Install.FieldInTypeAlias.makeRule "Types" "FrontendModel" "username : String"
+    , Install.FieldInTypeAlias.makeRule "Types" "FrontendModel" "email : String"
+
+    -- Type BackendModel
+    , Install.FieldInTypeAlias.makeRule "Types" "BackendModel" "pendingAuths : Dict Lamdera.SessionId Auth.Common.PendingAuth"
+    , Install.FieldInTypeAlias.makeRule "Types" "BackendModel" "pendingEmailAuths : Dict Lamdera.SessionId Auth.Common.PendingEmailAuth"
+    , Install.FieldInTypeAlias.makeRule "Types" "BackendModel" "sessions : Dict SessionId Auth.Common.UserInfo"
+    , Install.FieldInTypeAlias.makeRule "Types" "BackendModel" "secretCounter : Int"
+    , Install.FieldInTypeAlias.makeRule "Types" "BackendModel" "sessionDict : AssocList.Dict SessionId String"
+    , Install.FieldInTypeAlias.makeRule "Types" "BackendModel" "pendingLogins: MagicLink.Types.PendingLogins"
+    , Install.FieldInTypeAlias.makeRule "Types" "BackendModel" "log : MagicLink.Types.Log"
+    , Install.FieldInTypeAlias.makeRule "Types" "BackendModel" "users: Dict.Dict User.EmailString User.User"
+    , Install.FieldInTypeAlias.makeRule "Types" "BackendModel" "userNameToEmailString : Dict.Dict User.Username User.EmailString"
+    , Install.FieldInTypeAlias.makeRule "Types" "BackendModel" "sessionInfo : Session.SessionInfo"
+
+    -- Type ToBackend
+    , Install.TypeVariant.makeRule "Types" "ToBackend" "AuthToBackend Auth.Common.ToBackend"
+    , Install.TypeVariant.makeRule "Types" "ToBackend" "AddUser String String String"
+    , Install.TypeVariant.makeRule "Types" "ToBackend" "RequestSignup String String String"
+
+    -- Type BackendMsg
+    , Install.TypeVariant.makeRule "Types" "BackendMsg" "AuthBackendMsg Auth.Common.BackendMsg"
+    , Install.TypeVariant.makeRule "Types" "BackendMsg" "AutoLogin SessionId User.LoginData"
+
+    -- Type ToFrontend
+    , Install.TypeVariant.makeRule "Types" "ToFrontend" "AuthToFrontend Auth.Common.ToFrontend"
+    , Install.TypeVariant.makeRule "Types" "ToFrontend" "AuthSuccess Auth.Common.UserInfo"
+    , Install.TypeVariant.makeRule "Types" "ToFrontend" "UserInfoMsg (Maybe Auth.Common.UserInfo)"
+    , Install.TypeVariant.makeRule "Types" "ToFrontend" "CheckSignInResponse (Result BackendDataStatus User.LoginData)"
+    , Install.TypeVariant.makeRule "Types" "ToFrontend" "GetLoginTokenRateLimited"
+    , Install.TypeVariant.makeRule "Types" "ToFrontend" "RegistrationError String"
+    , Install.TypeVariant.makeRule "Types" "ToFrontend" "SignInError String"
+    , Install.TypeVariant.makeRule "Types" "ToFrontend" "UserSignedIn (Maybe User.User)"
     ]
 
 

--- a/preview/src/ReviewConfig.elm
+++ b/preview/src/ReviewConfig.elm
@@ -14,7 +14,6 @@ when inside the directory containing this file.
 import Install.ClauseInCase
 import Install.FieldInTypeAlias
 import Install.Function
-import Install.Type
 import Install.Import
 import Install.Initializer
 import Install.Type
@@ -80,8 +79,6 @@ config =
     , Install.TypeVariant.makeRule "Types" "ToFrontend" "SignInError String"
     , Install.TypeVariant.makeRule "Types" "ToFrontend" "UserSignedIn (Maybe User.User)"
     ]
-
-
 
 
 viewFunction =

--- a/src/Install/Function.elm
+++ b/src/Install/Function.elm
@@ -18,7 +18,6 @@ Running this rule will insert or replace the function `view` in the module `Fron
 
 -}
 
-import Elm.Interface exposing (Exposed(..))
 import Elm.Syntax.Declaration exposing (Declaration(..))
 import Elm.Syntax.Expression exposing (Expression, Function)
 import Elm.Syntax.ModuleName exposing (ModuleName)

--- a/src/Install/Function.elm
+++ b/src/Install/Function.elm
@@ -32,7 +32,7 @@ import Review.ModuleNameLookupTable exposing (ModuleNameLookupTable)
 import Review.Rule as Rule exposing (Error, Rule)
 
 
-{-| Configuration for makeRule: add a clause to a case expression in a specified function in a specified module.
+{-| Configuration for makeRule: add (or replace if function already exists) a function in a specified module.
 -}
 type Config
     = Config

--- a/src/Install/Function.elm
+++ b/src/Install/Function.elm
@@ -1,4 +1,4 @@
-module Install.Function exposing (makeRule, init, Config, CustomError)
+module Install.Function exposing (makeRule, init, Config, CustomError, withInsertAfter)
 
 {-| Replace a function in a given module with a new implementation or
 add that function definition if it is not present in the module.
@@ -14,15 +14,16 @@ add that function definition if it is not present in the module.
 
 Running this rule will insert or replace the function `view` in the module `Frontend` with the new implementation.
 
-@docs makeRule, init, Config, CustomError
+@docs makeRule, init, Config, CustomError, withInsertAfter
 
 -}
 
+import Elm.Interface exposing (Exposed(..))
 import Elm.Syntax.Declaration exposing (Declaration(..))
 import Elm.Syntax.Expression exposing (Expression, Function)
 import Elm.Syntax.ModuleName exposing (ModuleName)
 import Elm.Syntax.Node as Node exposing (Node)
-import Elm.Syntax.Range exposing (Range)
+import Elm.Syntax.Range as Range exposing (Range)
 import Install.Infer as Infer
 import Install.Library
 import Install.Normalize as Normalize
@@ -33,13 +34,15 @@ import Review.Rule as Rule exposing (Error, Rule)
 
 {-| Configuration for makeRule: add a clause to a case expression in a specified function in a specified module.
 -}
-type alias Config =
-    { moduleName : String
-    , functionName : String
-    , functionImplementation : String
-    , theFunctionNodeExpression : Maybe (Node Expression)
-    , customErrorMessage : CustomError
-    }
+type Config
+    = Config
+        { moduleName : String
+        , functionName : String
+        , functionImplementation : String
+        , theFunctionNodeExpression : Maybe (Node Expression)
+        , customErrorMessage : CustomError
+        , insertAt : InsertAt
+        }
 
 
 {-| Custom error message to be displayed when running `elm-review --fix` or `elm-review --fix-all`
@@ -48,16 +51,30 @@ type CustomError
     = CustomError { message : String, details : List String }
 
 
+type InsertAt
+    = After String
+    | AtEnd
+
+
+{-| Add the function after a specified declaration. Just give the name of a function, type, type alias or port and the function will be added after that declaration. Only work if the function is being added and not replaced.
+-}
+withInsertAfter : String -> Config -> Config
+withInsertAfter previousDeclaration (Config config) =
+    Config { config | insertAt = After previousDeclaration }
+
+
 {-| Initialize the configuration for the rule.
 -}
 init : List String -> String -> String -> Config
 init moduleNameList functionName functionImplementation =
-    { moduleName = String.join "." moduleNameList
-    , functionName = functionName
-    , functionImplementation = functionImplementation
-    , theFunctionNodeExpression = Install.Library.maybeNodeExpressionFromString { moduleName = moduleNameList } functionImplementation
-    , customErrorMessage = CustomError { message = "Replace function \"" ++ functionName ++ "\" with new code.", details = [ "" ] }
-    }
+    Config
+        { moduleName = String.join "." moduleNameList
+        , functionName = functionName
+        , functionImplementation = functionImplementation
+        , theFunctionNodeExpression = Install.Library.maybeNodeExpressionFromString { moduleName = moduleNameList } functionImplementation
+        , customErrorMessage = CustomError { message = "Replace function \"" ++ functionName ++ "\" with new code.", details = [ "" ] }
+        , insertAt = AtEnd
+        }
 
 
 {-| Create a rule that replaces a function in a given module with a new implementation or
@@ -72,6 +89,7 @@ makeRule config =
     in
     Rule.newModuleRuleSchemaUsingContextCreator "Install.Function" initialContext
         |> Rule.withDeclarationEnterVisitor visitor
+        |> Rule.withFinalModuleEvaluation (finalEvaluation config)
         |> Rule.providesFixesForModuleRule
         |> Rule.fromModuleRuleSchema
 
@@ -79,25 +97,40 @@ makeRule config =
 type alias Context =
     { moduleName : ModuleName
     , lookupTable : ModuleNameLookupTable
+    , lastDeclarationRange : Range
+    , appliedFix : Bool
     }
 
 
-initialContext : Rule.ContextCreator () { moduleName : ModuleName, lookupTable : ModuleNameLookupTable }
+initialContext : Rule.ContextCreator () Context
 initialContext =
     Rule.initContextCreator
-        (\lookupTable moduleName () -> { lookupTable = lookupTable, moduleName = moduleName })
+        (\lookupTable moduleName () -> { lookupTable = lookupTable, moduleName = moduleName, lastDeclarationRange = Range.empty, appliedFix = False })
         |> Rule.withModuleNameLookupTable
         |> Rule.withModuleName
 
 
 declarationVisitor : Context -> Config -> Node Declaration -> ( List (Rule.Error {}), Context )
-declarationVisitor context config declaration =
+declarationVisitor context (Config config) declaration =
+    let
+        contextWithLastDeclarationRange =
+            case config.insertAt of
+                After previousDeclaration ->
+                    if getDeclarationName declaration == previousDeclaration then
+                        { context | lastDeclarationRange = Node.range declaration }
+
+                    else
+                        context
+
+                AtEnd ->
+                    { context | lastDeclarationRange = Node.range declaration }
+    in
     case Node.value declaration of
         FunctionDeclaration function ->
             let
                 name : String
                 name =
-                    Node.value (Node.value function.declaration).name
+                    getDeclarationName declaration
 
                 isInCorrectModule =
                     Install.Library.isInCorrectModule config.moduleName context
@@ -114,26 +147,70 @@ declarationVisitor context config declaration =
                         == Just Normalize.ConfirmedEquality
                         |> not
             in
-            if name == config.functionName && isInCorrectModule then
-                if isNotImplemented function config then
-                    fixError (Node.range declaration) config context
-
-                else
-                    ( [], context )
+            if name == config.functionName && isInCorrectModule && isNotImplemented function config then
+                replaceFunction { range = Node.range declaration, functionName = config.functionName, functionImplementation = config.functionImplementation } context
 
             else
-                ( [], context )
+                ( [], contextWithLastDeclarationRange )
 
         _ ->
-            ( [], context )
+            ( [], contextWithLastDeclarationRange )
 
 
-fixError : Range -> Config -> Context -> ( List (Error {}), Context )
-fixError range config context =
+type alias FixConfig =
+    { range : Range
+    , functionName : String
+    , functionImplementation : String
+    }
+
+
+finalEvaluation : Config -> Context -> List (Rule.Error {})
+finalEvaluation (Config config) context =
+    if not context.appliedFix && Install.Library.isInCorrectModule config.moduleName context then
+        addFunction { range = context.lastDeclarationRange, functionName = config.functionName, functionImplementation = config.functionImplementation }
+
+    else
+        []
+
+
+replaceFunction : FixConfig -> Context -> ( List (Error {}), Context )
+replaceFunction fixConfig context =
     ( [ Rule.errorWithFix
-            { message = "Replace function \"" ++ config.functionName ++ "\"", details = [ "" ] }
-            range
-            [ Fix.replaceRangeBy range config.functionImplementation ]
+            { message = "Replace function \"" ++ fixConfig.functionName ++ "\"", details = [ "" ] }
+            fixConfig.range
+            [ Fix.replaceRangeBy fixConfig.range fixConfig.functionImplementation ]
       ]
-    , context
+    , { context | appliedFix = True }
     )
+
+
+addFunction : FixConfig -> List (Error {})
+addFunction fixConfig =
+    [ Rule.errorWithFix
+        { message = "Add function \"" ++ fixConfig.functionName ++ "\"", details = [ "" ] }
+        fixConfig.range
+        [ Fix.insertAt { row = fixConfig.range.end.row + 1, column = 0 } fixConfig.functionImplementation ]
+    ]
+
+
+getDeclarationName : Node Declaration -> String
+getDeclarationName declaration =
+    let
+        getName declaration_ =
+            declaration_ |> .name >> Node.value
+    in
+    case Node.value declaration of
+        FunctionDeclaration function ->
+            getName (Node.value function.declaration)
+
+        AliasDeclaration alias_ ->
+            getName alias_
+
+        CustomTypeDeclaration customType ->
+            getName customType
+
+        PortDeclaration port_ ->
+            getName port_
+
+        _ ->
+            ""

--- a/src/Install/Type.elm
+++ b/src/Install/Type.elm
@@ -23,10 +23,9 @@ import Elm.Syntax.Import exposing (Import)
 import Elm.Syntax.ModuleName exposing (ModuleName)
 import Elm.Syntax.Node as Node exposing (Node)
 import Elm.Syntax.Range as Range exposing (Range)
-import Elm.Syntax.Type exposing (Type)
 import Install.Library
 import List.Extra
-import Review.Fix as Fix exposing (Fix)
+import Review.Fix as Fix
 import Review.Rule as Rule exposing (Error, Rule)
 
 
@@ -131,38 +130,3 @@ initialContext =
     Rule.initContextCreator
         (\moduleName () -> { moduleName = moduleName, typeIsPresent = False, lastNodeRange = Range.empty })
         |> Rule.withModuleName
-
-
-contextCreator : Rule.ContextCreator () { moduleName : ModuleName }
-contextCreator =
-    Rule.initContextCreator
-        (\moduleName () ->
-            { moduleName = moduleName
-
-            -- ...other fields
-            }
-        )
-        |> Rule.withModuleName
-
-
-errorWithFix : String -> String -> String -> Node a -> Maybe Range -> Error {}
-errorWithFix typeName_ variantName_ variantCode_ node errorRange =
-    Rule.errorWithFix
-        { message = "Add " ++ variantName_ ++ " to " ++ typeName_
-        , details =
-            [ ""
-            ]
-        }
-        (Node.range node)
-        (case errorRange of
-            Just range ->
-                [ fixMissingVariant range.end variantCode_ ]
-
-            Nothing ->
-                []
-        )
-
-
-fixMissingVariant : { row : Int, column : Int } -> String -> Fix
-fixMissingVariant { row, column } variantCode =
-    Fix.insertAt { row = row, column = column } variantCode

--- a/tests/Install/FunctionTest.elm
+++ b/tests/Install/FunctionTest.elm
@@ -10,6 +10,11 @@ all : Test
 all =
     describe "Install.Function"
         [ Run.testFix test1
+        , Run.testFix test2
+        , Run.testFix test3
+        , Run.testFix test4
+        , Run.testFix test4a
+        , Run.testFix test4b
         ]
 
 
@@ -34,7 +39,7 @@ rule1 =
         [ "Frontend" ]
         "view"
         """view model =
-   Html.text "This is a test\""""
+    Html.text "This is a test\""""
         |> Install.Function.makeRule
 
 
@@ -42,19 +47,286 @@ src1 : String
 src1 =
     """module Frontend exposing(..)
 
+type Model = String
+
+init string =
+    (string, Cmd.none)
+
 view model =
-   Html.div [] [ Html.text "Hello, World!" ]"""
+    Html.div [] [ Html.text "Hello, World!" ]
+
+update msg model =
+    case msg of
+        _ ->
+            model"""
 
 
 under1 : String
 under1 =
     """view model =
-   Html.div [] [ Html.text "Hello, World!" ]"""
+    Html.div [] [ Html.text "Hello, World!" ]"""
 
 
 fixed1 : String
 fixed1 =
     """module Frontend exposing(..)
 
+type Model = String
+
+init string =
+    (string, Cmd.none)
+
 view model =
-   Html.text "This is a test\""""
+    Html.text "This is a test"
+
+update msg model =
+    case msg of
+        _ ->
+            model"""
+
+
+
+-- TEST 2 - Should add a new function
+
+
+test2 : { description : String, src : String, rule : Rule, under : String, fixed : String, message : String }
+test2 =
+    { description = "Test 2, add a new function"
+    , src = src1
+    , rule = rule2
+    , under = under2
+    , fixed = fixed2
+    , message = "Add function \"newFunction\""
+    }
+
+
+rule2 : Rule
+rule2 =
+    Install.Function.init
+        [ "Frontend" ]
+        "newFunction"
+        """newFunction model =
+    Html.text "This is a test\""""
+        |> Install.Function.makeRule
+
+
+under2 : String
+under2 =
+    """update msg model =
+    case msg of
+        _ ->
+            model"""
+
+
+fixed2 : String
+fixed2 =
+    """module Frontend exposing(..)
+
+type Model = String
+
+init string =
+    (string, Cmd.none)
+
+view model =
+    Html.div [] [ Html.text "Hello, World!" ]
+
+update msg model =
+    case msg of
+        _ ->
+            model
+newFunction model =
+    Html.text "This is a test\""""
+
+
+
+-- TEST 3 - Should add a new function when there is no function in the module
+
+
+test3 : { description : String, src : String, rule : Rule, under : String, fixed : String, message : String }
+test3 =
+    { description = "Test 3, add a new function when there is no function in the module"
+    , src = src3
+    , rule = rule3
+    , under = under3
+    , fixed = fixed3
+    , message = "Add function \"newFunction\""
+    }
+
+
+src3 : String
+src3 =
+    """module Frontend exposing(..)
+
+import Html exposing (Html)
+import Html.Attributes exposing (class)
+
+type alias Model =
+    {counter : Int}
+"""
+
+
+rule3 : Rule
+rule3 =
+    Install.Function.init
+        [ "Frontend" ]
+        "newFunction"
+        """newFunction model =
+    Html.text "This is a test\""""
+        |> Install.Function.makeRule
+
+
+under3 : String
+under3 =
+    """type alias Model =
+    {counter : Int}"""
+
+
+fixed3 : String
+fixed3 =
+    """module Frontend exposing(..)
+
+import Html exposing (Html)
+import Html.Attributes exposing (class)
+
+type alias Model =
+    {counter : Int}
+newFunction model =
+    Html.text "This is a test\""""
+
+
+
+-- TEST 4 - Should add a new function after a specific function
+
+
+test4 : { description : String, src : String, rule : Rule, under : String, fixed : String, message : String }
+test4 =
+    { description = "Test 4, add a new function after a specific function"
+    , src = src1
+    , rule = rule4
+    , under = under4
+    , fixed = fixed4
+    , message = "Add function \"newFunction\""
+    }
+
+
+rule4 : Rule
+rule4 =
+    Install.Function.init
+        [ "Frontend" ]
+        "newFunction"
+        """newFunction model =
+    Html.text "This is a test\""""
+        |> Install.Function.withInsertAfter "view"
+        |> Install.Function.makeRule
+
+
+under4 : String
+under4 =
+    """view model =
+    Html.div [] [ Html.text "Hello, World!" ]"""
+
+
+fixed4 : String
+fixed4 =
+    """module Frontend exposing(..)
+
+type Model = String
+
+init string =
+    (string, Cmd.none)
+
+view model =
+    Html.div [] [ Html.text "Hello, World!" ]
+newFunction model =
+    Html.text "This is a test"
+update msg model =
+    case msg of
+        _ ->
+            model"""
+
+
+test4a : { description : String, src : String, rule : Rule, under : String, fixed : String, message : String }
+test4a =
+    { description = "Test 4a, add a new function after a specific type"
+    , src = src1
+    , rule = rule4a
+    , under = under4a
+    , fixed = fixed4a
+    , message = "Add function \"newFunction\""
+    }
+
+
+rule4a : Rule
+rule4a =
+    Install.Function.init
+        [ "Frontend" ]
+        "newFunction"
+        """newFunction model =
+    Html.text "This is a test\""""
+        |> Install.Function.withInsertAfter "Model"
+        |> Install.Function.makeRule
+
+
+under4a : String
+under4a =
+    """type Model = String"""
+
+
+fixed4a : String
+fixed4a =
+    """module Frontend exposing(..)
+
+type Model = String
+newFunction model =
+    Html.text "This is a test"
+init string =
+    (string, Cmd.none)
+
+view model =
+    Html.div [] [ Html.text "Hello, World!" ]
+
+update msg model =
+    case msg of
+        _ ->
+            model"""
+
+
+test4b : { description : String, src : String, rule : Rule, under : String, fixed : String, message : String }
+test4b =
+    { description = "Test 4b, add a new function after a specific type alias"
+    , src = src3
+    , rule = rule4b
+    , under = under4b
+    , fixed = fixed4b
+    , message = "Add function \"newFunction\""
+    }
+
+
+rule4b : Rule
+rule4b =
+    Install.Function.init
+        [ "Frontend" ]
+        "newFunction"
+        """newFunction model =
+    Html.text "This is a test\""""
+        |> Install.Function.withInsertAfter "Model"
+        |> Install.Function.makeRule
+
+
+under4b : String
+under4b =
+    """type alias Model =
+    {counter : Int}"""
+
+
+fixed4b : String
+fixed4b =
+    """module Frontend exposing(..)
+
+import Html exposing (Html)
+import Html.Attributes exposing (class)
+
+type alias Model =
+    {counter : Int}
+newFunction model =
+    Html.text "This is a test\""""


### PR DESCRIPTION
Closes #13.

- Allow functions to be added either at the end of the module or after a declaration of choice
- Change `Config` to opaque type (**breaking change**)
- Add tests to new features