### PR TITLE
[Breaking change] [Install.Import] Allow adding multiple import statements

### DIFF
--- a/preview/src/ReviewConfig.elm
+++ b/preview/src/ReviewConfig.elm
@@ -27,11 +27,14 @@ config =
       Install.Type.makeRule "Types" "SignInState" [ "SignedOut", "SignUp", "SignedIn" ]
 
     -- TYPES IMPORTS
-    , Install.Import.init "Types" "Auth.Common" |> Install.Import.makeRule
-    , Install.Import.init "Types" "Url" |> Install.Import.makeRule
-    , Install.Import.init "Types" "MagicLink.Types" |> Install.Import.makeRule
-    , Install.Import.init "Types" "User" |> Install.Import.makeRule
-    , Install.Import.init "Types" "Session" |> Install.Import.makeRule
+    , Install.Import.init "Types"
+        [ { moduleToImport = "Auth.Common", alias_ = Nothing, exposedValues = Nothing }
+        , { moduleToImport = "Url", alias_ = Nothing, exposedValues = Nothing }
+        , { moduleToImport = "MagicLink.Types", alias_ = Nothing, exposedValues = Nothing }
+        , { moduleToImport = "User", alias_ = Nothing, exposedValues = Nothing }
+        , { moduleToImport = "Session", alias_ = Nothing, exposedValues = Nothing }
+        ]
+        |> Install.Import.makeRule
 
     -- Type Frontend, MagicLink
     , Install.FieldInTypeAlias.makeRule "Types" "FrontendModel" "authFlow : Auth.Common.Flow"

--- a/src/Install/Import.elm
+++ b/src/Install/Import.elm
@@ -1,19 +1,17 @@
-module Install.Import exposing (init, makeRule, withAlias, withExposedValues)
+module Install.Import exposing (init, makeRule)
 
 {-| Add import statements to a given module.
 For example, to add `import Foo.Bar` to the `Frontend` module, you can use the following configuration:
 
-    Install.Import.init "Frontend" "Foo.Bar"
+    Install.Import.init "Frontend" [ { moduleToImport = "Foo.Bar", alias_ = Nothing, exposedValues = Nothing } ]
         |> Install.Import.makeRule
 
 To add the statement `import Foo.Bar as FB exposing (a, b, c)` to the `Frontend` module, do this:
 
-    Install.Import.init "Frontend" "Foo.Bar"
-        |> Install.Import.withAlias "FB"
-        |> Install.Import.withExposedValues [ "a", "b", "c" ]
+    Install.Import.init "Frontend" [ { moduleToImport = "Foo.Bar", alias_ = Just "FB", exposedValues = Just [ "a", "b", "c" ] } ]
         |> Install.Import.makeRule
 
-@docs init, makeRule, withAlias, withExposedValues
+@docs init, makeRule
 
 -}
 
@@ -24,7 +22,6 @@ import Elm.Syntax.Node as Node exposing (Node)
 import Elm.Syntax.Range as Range exposing (Range)
 import Review.Fix as Fix
 import Review.Rule as Rule exposing (Error, Rule)
-import String.Extra
 
 
 {-|
@@ -32,11 +29,17 @@ import String.Extra
     Configuratioh for  the rule.
 
 -}
-type alias Config =
-    { hostModuleName : List String
-    , importedModuleName : List String
-    , customErrorMessage : CustomError
-    , importedModuleAlias : Maybe String
+type Config
+    = Config
+        { hostModuleName : List String
+        , imports : List ImportedModule
+        , customErrorMessage : CustomError
+        }
+
+
+type alias ImportedModule =
+    { moduleToImport : ModuleName
+    , alias_ : Maybe String
     , exposedValues : Maybe (List String)
     }
 
@@ -49,31 +52,16 @@ type CustomError
 
 {-| Initialize the configuration for the rule.
 -}
-init : String -> String -> Config
-init hostModuleName_ importedModuleName_ =
-    { hostModuleName = String.split "." hostModuleName_
-    , importedModuleName = String.split "." importedModuleName_
-    , customErrorMessage = CustomError { message = "Install module " ++ importedModuleName_ ++ " in " ++ importedModuleName_, details = [ "" ] }
-    , importedModuleAlias = Nothing
-    , exposedValues = Nothing
-    }
+init : String -> List { moduleToImport : String, alias_ : Maybe String, exposedValues : Maybe (List String) } -> Config
+init hostModuleName_ imports =
+    Config
+        { hostModuleName = String.split "." hostModuleName_
+        , imports = List.map (\{ moduleToImport, alias_, exposedValues } -> { moduleToImport = String.split "." moduleToImport, alias_ = alias_, exposedValues = exposedValues }) imports
+        , customErrorMessage = CustomError { message = "Install imports in module " ++ hostModuleName_, details = [ "" ] }
+        }
 
 
-{-| Add an alias to the imported module.
--}
-withAlias : String -> Config -> Config
-withAlias alias_ config =
-    { config | importedModuleAlias = Just alias_ }
-
-
-{-| Add an exposing list to the imported module.
--}
-withExposedValues : List String -> Config -> Config
-withExposedValues exposedValues config =
-    { config | exposedValues = Just exposedValues }
-
-
-{-| Create a rule that adds an import for a given module in a given module.
+{-| Create a rule that adds a list of imports for given modules in a given module.
 See above for examples.
 -}
 makeRule : Config -> Rule
@@ -90,25 +78,36 @@ type alias Context =
     { moduleName : ModuleName
     , moduleWasImported : Bool
     , lastNodeRange : Range
+    , foundImports : List (List String)
     }
 
 
 initialContext : Rule.ContextCreator () Context
 initialContext =
     Rule.initContextCreator
-        (\moduleName () -> { moduleName = moduleName, moduleWasImported = False, lastNodeRange = Range.empty })
+        (\moduleName () -> { moduleName = moduleName, moduleWasImported = False, lastNodeRange = Range.empty, foundImports = [] })
         |> Rule.withModuleName
 
 
 importVisitor : Config -> Node Import -> Context -> ( List (Error {}), Context )
-importVisitor config node context =
+importVisitor (Config config) node context =
     case Node.value node |> .moduleName |> Node.value of
         currentModuleName ->
-            if currentModuleName == config.importedModuleName && config.hostModuleName == context.moduleName then
+            let
+                allModuleNames =
+                    List.map .moduleToImport config.imports
+
+                foundImports =
+                    context.foundImports ++ [ currentModuleName ]
+
+                areAllImportsFound =
+                    List.all (\importedModuleName -> List.member importedModuleName foundImports) allModuleNames
+            in
+            if areAllImportsFound && config.hostModuleName == context.moduleName then
                 ( [], { context | moduleWasImported = True, lastNodeRange = Node.range node } )
 
             else
-                ( [], { context | lastNodeRange = Node.range node } )
+                ( [], { context | lastNodeRange = Node.range node, foundImports = foundImports } )
 
 
 moduleDefinitionVisitor : Node Module -> Context -> ( List (Error {}), Context )
@@ -118,24 +117,29 @@ moduleDefinitionVisitor def context =
 
 
 finalEvaluation : Config -> Context -> List (Rule.Error {})
-finalEvaluation config context =
+finalEvaluation (Config config) context =
     if context.moduleWasImported == False && config.hostModuleName == context.moduleName then
-        fixError config context
+        fixError config.imports context
 
     else
         []
 
 
-fixError : Config -> Context -> List (Error {})
-fixError config context =
+fixError : List ImportedModule -> Context -> List (Error {})
+fixError imports context =
     let
-        importText =
+        importText moduleToImport importedModuleAlias exposedValues =
             "import "
-                ++ String.join "." config.importedModuleName
-                ++ " "
-                |> addAlias config.importedModuleAlias
-                |> addExposing config.exposedValues
-                |> String.Extra.clean
+                ++ String.join "." moduleToImport
+                |> addAlias importedModuleAlias
+                |> addExposing exposedValues
+
+        uniqueImports =
+            List.filter (\importedModule -> not (List.member importedModule.moduleToImport context.foundImports)) imports
+
+        allImports =
+            List.map (\{ moduleToImport, alias_, exposedValues } -> importText moduleToImport alias_ exposedValues) uniqueImports
+                |> String.join "\n"
 
         addAlias : Maybe String -> String -> String
         addAlias mAlias str =
@@ -154,9 +158,22 @@ fixError config context =
 
                 Just exposedValues ->
                     str ++ " exposing (" ++ String.join ", " exposedValues ++ ")"
+
+        numberOfImports =
+            List.length uniqueImports
+
+        moduleName =
+            context.moduleName |> String.join "."
+
+        numberOfImportsText =
+            if numberOfImports == 1 then
+                String.fromInt numberOfImports ++ " import"
+
+            else
+                String.fromInt numberOfImports ++ " imports"
     in
     [ Rule.errorWithFix
-        { message = "moduleToImport: \"" ++ String.join "." config.importedModuleName ++ "\"", details = [ "" ] }
+        { message = "add " ++ numberOfImportsText ++ " to module " ++ moduleName, details = [ "" ] }
         context.lastNodeRange
-        [ Fix.insertAt { row = context.lastNodeRange.end.row + 1, column = context.lastNodeRange.end.column } importText ]
+        [ Fix.insertAt { row = context.lastNodeRange.end.row + 1, column = context.lastNodeRange.end.column } allImports ]
     ]

--- a/src/Install/Import.elm
+++ b/src/Install/Import.elm
@@ -1,14 +1,23 @@
-module Install.Import exposing (init, makeRule)
+module Install.Import exposing
+    ( init, makeRule
+    , initSimple
+    )
 
 {-| Add import statements to a given module.
 For example, to add `import Foo.Bar` to the `Frontend` module, you can use the following configuration:
 
-    Install.Import.init "Frontend" [ { moduleToImport = "Foo.Bar", alias_ = Nothing, exposedValues = Nothing } ]
+    Install.Import.init "Frontend"
+        [ { moduleToImport = "Foo.Bar", alias_ = Nothing, exposedValues = Nothing } ]
         |> Install.Import.makeRule
 
 To add the statement `import Foo.Bar as FB exposing (a, b, c)` to the `Frontend` module, do this:
 
     Install.Import.init "Frontend" [ { moduleToImport = "Foo.Bar", alias_ = Just "FB", exposedValues = Just [ "a", "b", "c" ] } ]
+        |> Install.Import.makeRule
+
+There is a short cut for importing modules with no alias or exposed values:
+
+    Install.Import.initSimple "Frontend" [ "Foo.Bar", "Baz.Qux" ]
         |> Install.Import.makeRule
 
 @docs init, makeRule
@@ -26,7 +35,7 @@ import Review.Rule as Rule exposing (Error, Rule)
 
 {-|
 
-    Configuratioh for  the rule.
+    Configuration for  the rule.
 
 -}
 type Config
@@ -57,6 +66,17 @@ init hostModuleName_ imports =
     Config
         { hostModuleName = String.split "." hostModuleName_
         , imports = List.map (\{ moduleToImport, alias_, exposedValues } -> { moduleToImport = String.split "." moduleToImport, alias_ = alias_, exposedValues = exposedValues }) imports
+        , customErrorMessage = CustomError { message = "Install imports in module " ++ hostModuleName_, details = [ "" ] }
+        }
+
+
+{-| Initialize the configuration for the rule.
+-}
+initSimple : String -> List String -> Config
+initSimple hostModuleName_ imports =
+    Config
+        { hostModuleName = String.split "." hostModuleName_
+        , imports = List.map (\moduleToImport -> { moduleToImport = String.split "." moduleToImport, alias_ = Nothing, exposedValues = Nothing }) imports
         , customErrorMessage = CustomError { message = "Install imports in module " ++ hostModuleName_, details = [ "" ] }
         }
 

--- a/tests/Install/ImportTest.elm
+++ b/tests/Install/ImportTest.elm
@@ -16,6 +16,7 @@ all =
         , Run.testFix test4
         , Run.expectNoErrorsTest test5.description test5.src test5.rule
         , Run.testFix test6
+        , Run.testFix test7
         ]
 
 
@@ -243,6 +244,31 @@ rule6 =
 
 fixed6 : String
 fixed6 =
+    """module Main exposing (..)
+
+import Set
+import Dict
+foo = 1"""
+
+
+test7 : { description : String, src : String, rule : Rule, under : String, fixed : String, message : String }
+test7 =
+    { description = "Should show correct number of imports to add when repeated imports are ignored"
+    , src = src1
+    , rule = rule7
+    , under = under1
+    , fixed = fixed7
+    , message = "add 1 import to module Main" --"Add Set and Dict to module Main using initSimple"
+    }
+
+
+rule7 : Rule
+rule7 =
+    Install.Import.initSimple "Main" [ "Set", "Dict" ] |> Install.Import.makeRule
+
+
+fixed7 : String
+fixed7 =
     """module Main exposing (..)
 
 import Set

--- a/tests/Install/ImportTest.elm
+++ b/tests/Install/ImportTest.elm
@@ -13,6 +13,9 @@ all =
         , Run.testFix test1a
         , Run.testFix test2
         , Run.testFix test3
+        , Run.testFix test4
+        , Run.expectNoErrorsTest test5.description test5.src test5.rule
+        , Run.testFix test6
         ]
 
 
@@ -27,13 +30,13 @@ test1 =
     , rule = rule1
     , under = under1
     , fixed = fixed1
-    , message = "moduleToImport: \"Dict\""
+    , message = "add 1 import to module Main"
     }
 
 
 rule1 : Rule
 rule1 =
-    Install.Import.init "Main" "Dict"
+    Install.Import.init "Main" [ { moduleToImport = "Dict", alias_ = Nothing, exposedValues = Nothing } ]
         |> Install.Import.makeRule
 
 
@@ -71,7 +74,7 @@ test1a =
     , rule = rule1
     , under = under1a
     , fixed = fixed1a
-    , message = "moduleToImport: \"Dict\""
+    , message = "add 1 import to module Main"
     }
 
 
@@ -105,14 +108,13 @@ test2 =
     , rule = rule2
     , under = under1
     , fixed = fixed2
-    , message = "moduleToImport: \"Dict\""
+    , message = "add 1 import to module Main"
     }
 
 
 rule2 : Rule
 rule2 =
-    Install.Import.init "Main" "Dict"
-        |> Install.Import.withAlias "D"
+    Install.Import.init "Main" [ { moduleToImport = "Dict", alias_ = Just "D", exposedValues = Nothing } ]
         |> Install.Import.makeRule
 
 
@@ -136,14 +138,13 @@ test3 =
     , rule = rule3
     , under = under1
     , fixed = fixed3
-    , message = "moduleToImport: \"Dict\""
+    , message = "add 1 import to module Main"
     }
 
 
 rule3 : Rule
 rule3 =
-    Install.Import.init "Main" "Dict"
-        |> Install.Import.withExposedValues [ "Dict" ]
+    Install.Import.init "Main" [ { moduleToImport = "Dict", alias_ = Nothing, exposedValues = Just [ "Dict" ] } ]
         |> Install.Import.makeRule
 
 
@@ -153,4 +154,97 @@ fixed3 =
 
 import Set
 import Dict exposing (Dict)
+foo = 1"""
+
+
+
+-- Test 4 - add multiple imports with aliases and exposed values
+
+
+test4 : { description : String, src : String, rule : Rule, under : String, fixed : String, message : String }
+test4 =
+    { description = "add multiple imports with aliases and exposed values"
+    , src = src1
+    , rule = rule4
+    , under = under1
+    , fixed = fixed4
+    , message = "add 5 imports to module Main"
+    }
+
+
+rule4 : Rule
+rule4 =
+    Install.Import.init "Main"
+        [ { moduleToImport = "Dict", alias_ = Just "D", exposedValues = Just [ "Dict" ] }
+        , { moduleToImport = "Html", alias_ = Nothing, exposedValues = Just [ "div" ] }
+        , { moduleToImport = "Html.Attributes", alias_ = Just "Attributes", exposedValues = Just [ "class, style, disabled, href, title, type_, name, novalidate, pattern, readonly, required, size, for, form, max, min, step, cols, rows, wrap" ] }
+        , { moduleToImport = "Pages.NestedModule.EvenMoreNested.MyPage", alias_ = Just "MyPage", exposedValues = Nothing }
+        , { moduleToImport = "Array", alias_ = Nothing, exposedValues = Just [ "Array" ] }
+        ]
+        |> Install.Import.makeRule
+
+
+fixed4 : String
+fixed4 =
+    """module Main exposing (..)
+
+import Set
+import Dict as D exposing (Dict)
+import Html exposing (div)
+import Html.Attributes as Attributes exposing (class, style, disabled, href, title, type_, name, novalidate, pattern, readonly, required, size, for, form, max, min, step, cols, rows, wrap)
+import Pages.NestedModule.EvenMoreNested.MyPage as MyPage
+import Array exposing (Array)
+foo = 1"""
+
+
+
+-- TEST 5 - should not report an error when import already exists
+
+
+test5 : { description : String, src : String, rule : Rule }
+test5 =
+    { description = "should not report an error when import already exists"
+    , src = src1
+    , rule = rule5
+    }
+
+
+rule5 : Rule
+rule5 =
+    Install.Import.init "Main"
+        [ { moduleToImport = "Set", alias_ = Nothing, exposedValues = Nothing }
+        ]
+        |> Install.Import.makeRule
+
+
+
+-- Test 6 - Should show correct number of imports to add when repeated imports are ignored
+
+
+test6 : { description : String, src : String, rule : Rule, under : String, fixed : String, message : String }
+test6 =
+    { description = "Should show correct number of imports to add when repeated importes are ignored"
+    , src = src1
+    , rule = rule6
+    , under = under1
+    , fixed = fixed6
+    , message = "add 1 import to module Main"
+    }
+
+
+rule6 : Rule
+rule6 =
+    Install.Import.init "Main"
+        [ { moduleToImport = "Set", alias_ = Nothing, exposedValues = Nothing }
+        , { moduleToImport = "Dict", alias_ = Nothing, exposedValues = Nothing }
+        ]
+        |> Install.Import.makeRule
+
+
+fixed6 : String
+fixed6 =
+    """module Main exposing (..)
+
+import Set
+import Dict
 foo = 1"""


### PR DESCRIPTION
- Changes `Install.Import.init` to receive a list of records of the type `{ moduleToImport : String, alias_ : Maybe String, exposedValues ​​: List String }`.
- Small tweak to checking to ensure duplicate imports won't prevent other imports from being installed.
- Adjust documentation to reflect new API
- Adjust previous tests to changes and create new tests

Closes #24.