### PR TITLE
Add stop condition to initializerCmd

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -19,6 +19,7 @@
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
         "elm/core": "1.0.5 <= v < 2.0.0",
+        "elm/regex": "1.0.0 <= v < 2.0.0",
         "elmcraft/core-extra": "2.0.0 <= v < 3.0.0",
         "jfmengels/elm-review": "2.13.0 <= v < 3.0.0",
         "pzp1997/assoc-list": "1.0.0 <= v < 2.0.0",

--- a/preview/src/ReviewConfig.elm
+++ b/preview/src/ReviewConfig.elm
@@ -41,7 +41,10 @@ import Review.Rule exposing (Rule)
 
 -}
 
-config = configAll
+
+config =
+    configAll
+
 
 configAll =
     configAtmospheric
@@ -110,30 +113,32 @@ configUsers =
     --    |> ReplaceFunction.makeRule
     ]
 
+
+
 -- HERE
+
+
 configMagicLinkMinimal : List Rule
 configMagicLinkMinimal =
     [ Import.qualified "Types" [ "Auth.Common", "MagicLink.Types" ] |> Import.makeRule
     , TypeVariant.makeRule "Types" "FrontendMsg" [ "AuthFrontendMsg MagicLink.Types.Msg" ]
     , TypeVariant.makeRule "Types" "BackendMsg" [ "AuthBackendMsg Auth.Common.BackendMsg" ]
-    , TypeVariant.makeRule "Types" "ToBackend"  [ "AuthToBackend Auth.Common.ToBackend" ]
+    , TypeVariant.makeRule "Types" "ToBackend" [ "AuthToBackend Auth.Common.ToBackend" ]
     , FieldInTypeAlias.makeRule "Types" "LoadedModel" [ "magicLinkModel : MagicLink.Types.Model" ]
     , Import.qualified "Frontend" [ "MagicLink.Types", "Auth.Common", "MagicLink.Frontend", "MagicLink.Auth", "Pages.SignIn", "Pages.Home", "Pages.Admin", "Pages.TermsOfService", "Pages.Notes" ] |> Import.makeRule
-    , Import.qualified "Backend" ["Auth.Flow"] |> Import.makeRule
+    , Import.qualified "Backend" [ "Auth.Flow" ] |> Import.makeRule
     , Initializer.makeRule "Frontend" "initLoaded" [ { field = "magicLinkModel", value = "Pages.SignIn.init loadingModel.initUrl" } ]
     , TypeVariant.makeRule "Types"
-            "ToFrontend"
-            [ "AuthToFrontend Auth.Common.ToFrontend"
-            , "AuthSuccess Auth.Common.UserInfo"
-            , "UserInfoMsg (Maybe Auth.Common.UserInfo)"
-            , "GetLoginTokenRateLimited"
-            , "RegistrationError String"
-            , "SignInError String"
-            ]
-      , ClauseInCase.init "Backend" "updateFromFrontend" "AuthToBackend authMsg" "Auth.Flow.updateFromFrontend (MagicLink.Auth.backendConfig model) clientId sessionId authMsg model" |> ClauseInCase.makeRule
-
+        "ToFrontend"
+        [ "AuthToFrontend Auth.Common.ToFrontend"
+        , "AuthSuccess Auth.Common.UserInfo"
+        , "UserInfoMsg (Maybe Auth.Common.UserInfo)"
+        , "GetLoginTokenRateLimited"
+        , "RegistrationError String"
+        , "SignInError String"
+        ]
+    , ClauseInCase.init "Backend" "updateFromFrontend" "AuthToBackend authMsg" "Auth.Flow.updateFromFrontend (MagicLink.Auth.backendConfig model) clientId sessionId authMsg model" |> ClauseInCase.makeRule
     ]
-
 
 
 configAuthTypes : List Rule

--- a/src/Install/InitializerCmd.elm
+++ b/src/Install/InitializerCmd.elm
@@ -104,21 +104,21 @@ visitCmd namespace moduleName functionName cmds ignored function context =
                     case expressions of
                         [ _, oldCmds ] ->
                             let
-                                val_ =
-                                    Node.value oldCmds
-
                                 range_ =
                                     Node.range oldCmds
                             in
-                            ( Just val_, range_ )
+                            ( Just oldCmds, range_ )
 
                         _ ->
                             ( Nothing, Elm.Syntax.Range.empty )
 
                 _ ->
                     ( Nothing, Elm.Syntax.Range.empty )
+
+        stringifiedCmds =
+            Maybe.map Install.Library.expressionToString val
     in
-    if isInCorrectModule then
+    if isInCorrectModule && stringifiedCmds == Just "Cmd.none" then
         ( [ errorWithFix cmds function.declaration (Just range) ], context )
 
     else

--- a/src/Install/Subscription.elm
+++ b/src/Install/Subscription.elm
@@ -25,7 +25,7 @@ import Set.Extra
 
 and that you want to add `baz` to the list. To do this, say
 
-    Insall.Subscription.makeRule "Backend" ["baz"]
+    Insall.Subscription.makeRule "Backend" [ "baz" ]
 
 The result is
 
@@ -132,7 +132,7 @@ declarationVisitor moduleName items (Node _ declaration) context =
                                             replacementCode =
                                                 items
                                                     |> Set.toList
-                                                    |> List.map (\item -> (", ") ++ item)
+                                                    |> List.map (\item -> ", " ++ item)
                                                     |> String.concat
                                         in
                                         ( [ errorWithFix replacementCode nameRange endOfRange rest ], context )

--- a/tests/Install/FieldInTypeAliasTest.elm
+++ b/tests/Install/FieldInTypeAliasTest.elm
@@ -23,7 +23,7 @@ type alias Client =
     , age : Int
     }
     """
-    , rule = Install.FieldInTypeAlias.makeRule "Client" "Client" ["name : String"]
+    , rule = Install.FieldInTypeAlias.makeRule "Client" "Client" [ "name : String" ]
     }
 
 
@@ -34,7 +34,7 @@ type alias Client =
     { age : Int
     }
     """
-    , rule = Install.FieldInTypeAlias.makeRule "Client" "Client" ["name : String"]
+    , rule = Install.FieldInTypeAlias.makeRule "Client" "Client" [ "name : String" ]
     , under = """type alias Client =
     { age : Int
     }"""
@@ -55,7 +55,7 @@ type alias Client =
     { age : Int
     }
     """
-    , rule = Install.FieldInTypeAlias.makeRule "Data.Client" "Client" ["name : String"]
+    , rule = Install.FieldInTypeAlias.makeRule "Data.Client" "Client" [ "name : String" ]
     , under = """type alias Client =
     { age : Int
     }"""
@@ -68,7 +68,10 @@ type alias Client =
     , message = "Add name to Client"
     }
 
+
+
 -- Test 4: should add multiple fields
+
 
 test4 =
     { description = "should add multiple fields"
@@ -77,7 +80,7 @@ type alias Client =
     { age : Int
     }
     """
-    , rule = Install.FieldInTypeAlias.makeRule "Client" "Client" ["name : String", "email : String", "age : Int", "lastName : String", "favoriteColor : String"]
+    , rule = Install.FieldInTypeAlias.makeRule "Client" "Client" [ "name : String", "email : String", "age : Int", "lastName : String", "favoriteColor : String" ]
     , under = """type alias Client =
     { age : Int
     }"""
@@ -92,4 +95,3 @@ type alias Client =
     """
     , message = "Add fields email, favoriteColor, lastName, name to Client"
     }
-

--- a/tests/Install/InitializerCmdTest.elm
+++ b/tests/Install/InitializerCmdTest.elm
@@ -8,11 +8,13 @@ import Test exposing (Test, describe)
 all : Test
 all =
     describe "Install.Initializer"
-        [ Run.testFix test1 ]
+        [ Run.testFix test1
+        , Run.expectNoErrorsTest test2.description test2.src test2.rule
+        ]
 
 
 test1 =
-    { description = "should not report an error when the field already exists"
+    { description = "should insert multiple fields"
     , src = """module Client exposing (..)
 init : (Model, Cmd Msg)
 init =
@@ -36,6 +38,17 @@ init =
     )
 """
     , message = "Add cmds Task.perform GotFastTick, Helper.getAtmosphericRandomNumbers to the model"
+    }
+
+
+
+-- test2 - should not report error when the field already exists
+
+
+test2 =
+    { description = "should not report an error when the field already exists"
+    , src = test1.fixed
+    , rule = Install.InitializerCmd.makeRule "Client" "init" [ "Task.perform GotFastTick", "Helper.getAtmosphericRandomNumbers" ]
     }
 
 

--- a/tests/Install/SubTest.elm
+++ b/tests/Install/SubTest.elm
@@ -21,7 +21,7 @@ test1 =
 subscriptions model =
   Sub.batch [ foo model ]
 """
-    , rule = Install.Subscription.makeRule "Backend" ["bar model"]
+    , rule = Install.Subscription.makeRule "Backend" [ "bar model" ]
     , under = """subscriptions"""
     , fixed = """module Backend exposing (..)
 
@@ -39,11 +39,13 @@ test2 =
 subscriptions model =
   Sub.batch [ foo model, bar model ]
 """
-    , rule = Install.Subscription.makeRule "Backend" ["bar model"]
+    , rule = Install.Subscription.makeRule "Backend" [ "bar model" ]
     }
 
 
+
 -- test3 - should add multiple items
+
 
 test3 =
     { description = "should add multiple items to subscriptions"
@@ -52,7 +54,7 @@ test3 =
 subscriptions model =
   Sub.batch [ foo model ]
 """
-    , rule = Install.Subscription.makeRule "Backend" ["bar model", "baz model"]
+    , rule = Install.Subscription.makeRule "Backend" [ "bar model", "baz model" ]
     , under = """subscriptions"""
     , fixed = """module Backend exposing (..)
 


### PR DESCRIPTION
Add stop condition to avoid false positives. It is a very imperfect solution since it only checks if the current Cmd is `==` to `Cmd.none`