### PR TITLE
Bug/element to list: fix infinite loop bug in ElementToList

### DIFF
--- a/src/Install/Library.elm
+++ b/src/Install/Library.elm
@@ -334,7 +334,7 @@ expressionToString (Node _ expression) =
             String.join " " (List.map expressionToString children)
 
         TupledExpression children ->
-            "(" ++ String.join ", " (List.map expressionToString children) ++ ")"
+            "(" ++ String.join ", " (List.map expressionToString children) ++ ")" |> Debug.log "TupledExpression"
 
         ListExpr children ->
             "[" ++ String.join ", " (List.map expressionToString children) ++ "]"

--- a/src/Install/Library.elm
+++ b/src/Install/Library.elm
@@ -334,7 +334,7 @@ expressionToString (Node _ expression) =
             String.join " " (List.map expressionToString children)
 
         TupledExpression children ->
-            "(" ++ String.join ", " (List.map expressionToString children) ++ ")" |> Debug.log "TupledExpression"
+            "(" ++ String.join ", " (List.map expressionToString children) ++ ")"
 
         ListExpr children ->
             "[" ++ String.join ", " (List.map expressionToString children) ++ "]"
@@ -347,6 +347,9 @@ expressionToString (Node _ expression) =
 
         RecordAccess child field ->
             expressionToString child ++ "." ++ Node.value field
+
+        Literal str ->
+            "\"" ++ str ++ "\""
 
         -- CaseExpression caseBlock ->
         --     "case " ++ expressionToString caseBlock.expression ++ " of " ++ String.join " " (List.map caseToString caseBlock.cases)

--- a/tests/Install/ElementToListTest.elm
+++ b/tests/Install/ElementToListTest.elm
@@ -11,6 +11,7 @@ all =
         [ Run.testFix test1
         , Run.expectNoErrorsTest "should not report error when the field already exists" src0 rule1
         , Run.testFix test2
+        --, Run.testFix test3
         ]
 
 
@@ -116,6 +117,59 @@ under2 =
 
 
 fixed2 =
+    """module Contributors exposing (..)
+
+type Contributors
+    = Jxx
+    | Matt
+    | Laozi
+
+contributors : List Contributors
+contributors =
+    [ Jxx, Matt, Laozi ]
+"""
+
+-- TEST 3
+
+
+
+test3 =
+    { description = "should add multiple elements to the list in project with two modules"
+    , src = src3
+    , rule = rule3
+    , under = under3
+    , fixed = fixed3
+    , message = "Add 2 elements to the list in project with two modules"
+    }
+
+
+src3 =
+    """module Contributors exposing (..)
+
+type Contributors
+    = Jxx
+    | Matt
+    | Laozi
+
+contributors : List Contributors
+contributors =
+    [ Jxx ]
+
+ module Foo exposing(..)
+
+ bar = 1
+"""
+
+
+rule3 =
+    makeRule "Contributors" "contributors" [ "Matt", "Laozi" ]
+
+
+under3 =
+    """[ Jxx ]"""
+
+
+fixed3 =
     """module Contributors exposing (..)
 
 type Contributors

--- a/tests/Install/ElementToListTest.elm
+++ b/tests/Install/ElementToListTest.elm
@@ -11,7 +11,7 @@ all =
         [ Run.testFix test1
         , Run.expectNoErrorsTest "should not report error when the field already exists" src0 rule1
         , Run.testFix test2
-        --, Run.testFix test3
+        , Run.testFix test4
         ]
 
 
@@ -129,55 +129,52 @@ contributors =
     [ Jxx, Matt, Laozi ]
 """
 
--- TEST 3
 
 
+-- TEST 4
 
-test3 =
-    { description = "should add multiple elements to the list in project with two modules"
-    , src = src3
-    , rule = rule3
-    , under = under3
-    , fixed = fixed3
-    , message = "Add 2 elements to the list in project with two modules"
+
+test4 =
+    { description = "should add an element to a list of tuples in project"
+    , src = src4
+    , rule = rule4
+    , under = under4
+    , fixed = fixed4
+    , message = "Add an element to a list of tuples in project"
     }
 
 
-src3 =
-    """module Contributors exposing (..)
+src4 =
+    """module Routes exposing (..)
 
-type Contributors
-    = Jxx
-    | Matt
-    | Laozi
+type Route
+    = HomepageRoute
+    | Quotes
 
-contributors : List Contributors
-contributors =
-    [ Jxx ]
 
- module Foo exposing(..)
-
- bar = 1
+routesAndNames : List (Route, String)
+routesAndNames =
+    [(HomepageRoute, "homepage")]
 """
 
 
-rule3 =
-    makeRule "Contributors" "contributors" [ "Matt", "Laozi" ]
+rule4 =
+    makeRule "Routes" "routesAndNames" [ "(Quotes, \"quotes\")" ]
 
 
-under3 =
-    """[ Jxx ]"""
+under4 =
+    """[(HomepageRoute, "homepage")]"""
 
 
-fixed3 =
-    """module Contributors exposing (..)
-
-type Contributors
-    = Jxx
-    | Matt
-    | Laozi
-
-contributors : List Contributors
-contributors =
-    [ Jxx, Matt, Laozi ]
-"""
+fixed4 =
+    """module Routes exposing (..)
+   
+   type Route
+       = HomepageRoute
+       | Quotes
+       | Jokes
+   
+   routesAndNames : List (Route, String)
+   routesAndNames =
+       [(HomepageRoute, "homepage"), (Quotes, "quotes")]
+   """

--- a/tests/Install/ElementToListTest.elm
+++ b/tests/Install/ElementToListTest.elm
@@ -140,7 +140,7 @@ test4 =
     , rule = rule4
     , under = under4
     , fixed = fixed4
-    , message = "Add an element to a list of tuples in project"
+    , message = "Add 2 elements to the list"
     }
 
 
@@ -150,7 +150,6 @@ src4 =
 type Route
     = HomepageRoute
     | Quotes
-
 
 routesAndNames : List (Route, String)
 routesAndNames =
@@ -168,13 +167,12 @@ under4 =
 
 fixed4 =
     """module Routes exposing (..)
-   
-   type Route
-       = HomepageRoute
-       | Quotes
-       | Jokes
-   
-   routesAndNames : List (Route, String)
-   routesAndNames =
-       [(HomepageRoute, "homepage"), (Quotes, "quotes")]
-   """
+
+type Route
+    = HomepageRoute
+    | Quotes
+
+routesAndNames : List (Route, String)
+routesAndNames =
+    [(HomepageRoute, "homepage"), (Quotes, "quotes")]
+"""


### PR DESCRIPTION
All that was needed was to implement the `Literal String` case in expressionToString of module Library